### PR TITLE
feat: Add global search bar with Algolia-style autocomplete

### DIFF
--- a/recom_sys_app/templates/recom_sys_app/movie_search.html
+++ b/recom_sys_app/templates/recom_sys_app/movie_search.html
@@ -87,6 +87,8 @@
       margin-bottom: 40px;
       flex-wrap: wrap;
       gap: 20px;
+      position: relative;
+      z-index: 100;
     }
 
     .logo-section {
@@ -134,6 +136,174 @@
     .btn-back:hover {
       transform: translateY(-2px);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+
+    /* Global Search Bar Styles */
+    .global-search-container {
+      position: relative;
+      flex: 1;
+      max-width: 400px;
+      margin: 0 20px;
+      z-index: 9999;
+    }
+
+    .global-search-wrapper {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+
+    .global-search-input {
+      width: 100%;
+      padding: 12px 16px 12px 42px;
+      border: 2px solid rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+      font-size: 0.95rem;
+      background: rgba(0, 0, 0, 0.6);
+      color: white;
+      transition: all 0.3s ease;
+    }
+
+    .global-search-input::placeholder {
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    .global-search-input:focus {
+      outline: none;
+      border-color: #E50914;
+      background: rgba(0, 0, 0, 0.8);
+      box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.15);
+    }
+
+    .global-search-icon {
+      position: absolute;
+      left: 14px;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 1rem;
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    .global-search-spinner {
+      position: absolute;
+      right: 14px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 18px;
+      height: 18px;
+      border: 2px solid rgba(229, 9, 20, 0.3);
+      border-top-color: #E50914;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      display: none;
+    }
+
+    .global-search-spinner.active {
+      display: block;
+    }
+
+    /* Autocomplete Dropdown */
+    .autocomplete-dropdown {
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 0;
+      right: 0;
+      background: rgba(15, 15, 15, 0.99);
+      border: 2px solid rgba(229, 9, 20, 0.4);
+      border-radius: 10px;
+      box-shadow: 0 25px 80px rgba(0, 0, 0, 0.95);
+      backdrop-filter: blur(20px);
+      max-height: 400px;
+      overflow-y: auto;
+      z-index: 9999;
+      display: none;
+      animation: dropdownFadeIn 0.2s ease;
+    }
+
+    .autocomplete-dropdown.active {
+      display: block;
+    }
+
+    @keyframes dropdownFadeIn {
+      from { opacity: 0; transform: translateY(-8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .autocomplete-item {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 14px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .autocomplete-item:last-child { border-bottom: none; }
+    .autocomplete-item:hover, .autocomplete-item.selected { background: rgba(229, 9, 20, 0.15); }
+    .autocomplete-item:first-child { border-radius: 10px 10px 0 0; }
+    .autocomplete-item:last-child { border-radius: 0 0 10px 10px; }
+    .autocomplete-item:only-child { border-radius: 10px; }
+
+    .autocomplete-poster {
+      width: 40px;
+      height: 60px;
+      border-radius: 5px;
+      object-fit: cover;
+      background: rgba(229, 9, 20, 0.2);
+      flex-shrink: 0;
+    }
+
+    .autocomplete-poster-placeholder {
+      width: 40px;
+      height: 60px;
+      border-radius: 5px;
+      background: linear-gradient(135deg, rgba(229, 9, 20, 0.3), rgba(0, 0, 0, 0.5));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      font-size: 1.2rem;
+    }
+
+    .autocomplete-info { flex: 1; min-width: 0; }
+
+    .autocomplete-title {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: white;
+      margin-bottom: 3px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .autocomplete-meta {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.8rem;
+      color: #999;
+    }
+
+    .autocomplete-year { color: #E50914; font-weight: 600; }
+    .autocomplete-rating { display: flex; align-items: center; gap: 3px; }
+    .autocomplete-rating-star { color: #ffd700; }
+
+    .autocomplete-no-results {
+      padding: 25px 16px;
+      text-align: center;
+      color: #999;
+    }
+
+    @media (max-width: 768px) {
+      .global-search-container {
+        max-width: none;
+        margin: 10px 0;
+        order: 3;
+        width: 100%;
+      }
     }
 
     /* Page Title */
@@ -416,6 +586,26 @@
         </div>
         <div class="logo-text">CineMatch</div>
       </div>
+      
+      <!-- Global Search Bar -->
+      <div class="global-search-container">
+        <div class="global-search-wrapper">
+          <span class="global-search-icon">🔍</span>
+          <input 
+            type="text" 
+            class="global-search-input" 
+            id="globalSearchInput"
+            placeholder="Quick search movies..."
+            autocomplete="off"
+            spellcheck="false"
+          >
+          <div class="global-search-spinner" id="searchSpinner"></div>
+        </div>
+        <div class="autocomplete-dropdown" id="autocompleteDropdown">
+          <div id="autocompleteResults"></div>
+        </div>
+      </div>
+      
       <a href="{% url 'recom_sys:profile' %}" class="btn-back">← Back to Profile</a>
     </div>
 
@@ -490,6 +680,187 @@
       }
       return cookieValue;
     }
+
+    // ==================== GLOBAL SEARCH BAR AUTOCOMPLETE ====================
+    const globalSearchInput = document.getElementById('globalSearchInput');
+    const autocompleteDropdown = document.getElementById('autocompleteDropdown');
+    const autocompleteResults = document.getElementById('autocompleteResults');
+    const searchSpinnerGlobal = document.getElementById('searchSpinner');
+    
+    let debounceTimerGlobal = null;
+    let currentQueryGlobal = '';
+    let selectedIndexGlobal = -1;
+    let currentResultsGlobal = [];
+    let abortControllerGlobal = null;
+    
+    function debounceGlobalSearch(query, delay = 250) {
+      clearTimeout(debounceTimerGlobal);
+      if (abortControllerGlobal) abortControllerGlobal.abort();
+      
+      if (!query || query.length < 2) {
+        hideAutocomplete();
+        return;
+      }
+      
+      showGlobalSpinner();
+      debounceTimerGlobal = setTimeout(() => performGlobalSearch(query), delay);
+    }
+    
+    async function performGlobalSearch(query) {
+      currentQueryGlobal = query;
+      abortControllerGlobal = new AbortController();
+      
+      try {
+        const response = await fetch(`/api/search/autocomplete/?q=${encodeURIComponent(query)}&limit=6`, {
+          signal: abortControllerGlobal.signal,
+        });
+        
+        if (!response.ok) throw new Error('Search failed');
+        const data = await response.json();
+        
+        if (data.success && query === currentQueryGlobal) {
+          currentResultsGlobal = data.results;
+          selectedIndexGlobal = -1;
+          renderAutocomplete(data.results, query);
+        }
+      } catch (error) {
+        if (error.name !== 'AbortError') {
+          autocompleteResults.innerHTML = '<div class="autocomplete-no-results">Search error. Try again.</div>';
+          showAutocomplete();
+        }
+      } finally {
+        hideGlobalSpinner();
+      }
+    }
+    
+    function renderAutocomplete(results, query) {
+      if (!results || results.length === 0) {
+        autocompleteResults.innerHTML = `<div class="autocomplete-no-results">No movies found for "${query}"</div>`;
+        showAutocomplete();
+        return;
+      }
+      
+      let html = '';
+      results.forEach((movie, index) => {
+        const posterHtml = movie.poster_url
+          ? `<img src="${movie.poster_url}" alt="${movie.title}" class="autocomplete-poster" loading="lazy">`
+          : `<div class="autocomplete-poster-placeholder">🎬</div>`;
+        
+        const ratingHtml = movie.vote_average > 0
+          ? `<span class="autocomplete-rating"><span class="autocomplete-rating-star">★</span> ${movie.vote_average}</span>`
+          : '';
+        
+        html += `
+          <div class="autocomplete-item" data-index="${index}" data-tmdb-id="${movie.tmdb_id}" data-title="${movie.title}" data-poster="${movie.poster_url || ''}" data-year="${movie.year || ''}">
+            ${posterHtml}
+            <div class="autocomplete-info">
+              <div class="autocomplete-title">${highlightMatchGlobal(movie.title, query)}</div>
+              <div class="autocomplete-meta">
+                ${movie.year ? `<span class="autocomplete-year">${movie.year}</span>` : ''}
+                ${ratingHtml}
+              </div>
+            </div>
+          </div>
+        `;
+      });
+      
+      autocompleteResults.innerHTML = html;
+      showAutocomplete();
+      
+      document.querySelectorAll('#autocompleteResults .autocomplete-item').forEach(item => {
+        item.addEventListener('click', () => selectFromAutocomplete(item));
+      });
+    }
+    
+    function highlightMatchGlobal(text, query) {
+      if (!query) return text;
+      const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+      return text.replace(regex, '<strong style="color: #E50914;">$1</strong>');
+    }
+    
+    function selectFromAutocomplete(item) {
+      const tmdbId = item.dataset.tmdbId;
+      const title = item.dataset.title;
+      const posterUrl = item.dataset.poster;
+      const year = item.dataset.year;
+      
+      // Fill the main search input and trigger search
+      document.getElementById('searchInput').value = title;
+      hideAutocomplete();
+      globalSearchInput.value = '';
+      
+      // Directly load similar movies for this selection
+      loadSimilarMoviesDirectly(tmdbId, title, posterUrl, year);
+    }
+    
+    async function loadSimilarMoviesDirectly(tmdbId, title, posterUrl, year) {
+      selectedMovieId = tmdbId;
+      selectedMovieData = { tmdb_id: tmdbId, title, poster_path: posterUrl ? posterUrl.replace('https://image.tmdb.org/t/p/w500', '') : null, year };
+      
+      // Show selected movie
+      showSelectedMovie(selectedMovieData);
+      
+      // Fetch similar movies
+      await fetchAndDisplaySimilarMovies(selectedMovieData);
+    }
+    
+    function showAutocomplete() { autocompleteDropdown.classList.add('active'); }
+    function hideAutocomplete() { autocompleteDropdown.classList.remove('active'); selectedIndexGlobal = -1; }
+    function showGlobalSpinner() { searchSpinnerGlobal.classList.add('active'); }
+    function hideGlobalSpinner() { searchSpinnerGlobal.classList.remove('active'); }
+    
+    globalSearchInput.addEventListener('input', (e) => debounceGlobalSearch(e.target.value.trim()));
+    
+    globalSearchInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const items = document.querySelectorAll('#autocompleteResults .autocomplete-item');
+        
+        // If an item is selected, use that
+        if (selectedIndexGlobal >= 0 && items[selectedIndexGlobal]) {
+          selectFromAutocomplete(items[selectedIndexGlobal]);
+        }
+        // If no item selected but we have results, auto-select the first one
+        else if (currentResultsGlobal.length > 0 && items.length > 0) {
+          selectFromAutocomplete(items[0]);
+        }
+        return;
+      }
+      
+      if (!autocompleteDropdown.classList.contains('active')) return;
+      
+      const items = document.querySelectorAll('#autocompleteResults .autocomplete-item');
+      
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        selectedIndexGlobal = Math.min(selectedIndexGlobal + 1, items.length - 1);
+        updateAutocompleteSelection(items);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        selectedIndexGlobal = Math.max(selectedIndexGlobal - 1, -1);
+        updateAutocompleteSelection(items);
+      } else if (e.key === 'Escape') {
+        hideAutocomplete();
+        globalSearchInput.blur();
+      }
+    });
+    
+    function updateAutocompleteSelection(items) {
+      items.forEach((item, index) => item.classList.toggle('selected', index === selectedIndexGlobal));
+      if (selectedIndexGlobal >= 0 && items[selectedIndexGlobal]) {
+        items[selectedIndexGlobal].scrollIntoView({ block: 'nearest' });
+      }
+    }
+    
+    globalSearchInput.addEventListener('focus', () => {
+      if (currentResultsGlobal.length > 0) showAutocomplete();
+    });
+    
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.global-search-container')) hideAutocomplete();
+    });
+    
+    // ==================== END GLOBAL SEARCH BAR ====================
 
     // Show message
     function showMessage(text, type = 'info') {
@@ -657,6 +1028,29 @@
 
       similarSection.innerHTML = html;
     }
+    
+    // ==================== HANDLE URL PARAMS (from global search) ====================
+    document.addEventListener('DOMContentLoaded', () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const movieId = urlParams.get('movie');
+      const movieTitle = urlParams.get('title');
+      const searchQuery = urlParams.get('q');
+      
+      // If movie ID is provided (from global search autocomplete)
+      if (movieId && movieTitle) {
+        // Set the search input value
+        document.getElementById('searchInput').value = movieTitle;
+        
+        // Load similar movies directly
+        loadSimilarMoviesDirectly(movieId, movieTitle, null, null);
+      }
+      // If just a search query is provided
+      else if (searchQuery) {
+        document.getElementById('searchInput').value = searchQuery;
+        // Trigger the search form
+        document.getElementById('searchForm').dispatchEvent(new Event('submit'));
+      }
+    });
   </script>
 </body>
 </html>

--- a/recom_sys_app/templates/recom_sys_app/profile.html
+++ b/recom_sys_app/templates/recom_sys_app/profile.html
@@ -63,10 +63,12 @@
       flex-wrap: wrap;
       gap: 20px;
       padding: 20px;
-      background: rgba(20, 20, 20, 0.8);
+      background: rgba(20, 20, 20, 0.95);
       border-radius: 12px;
       border: 1px solid rgba(229, 9, 20, 0.1);
       backdrop-filter: blur(10px);
+      position: relative;
+      z-index: 100;
     }
 
     .logo-section {
@@ -155,6 +157,272 @@
     .btn-logout:hover {
       background: rgba(229, 9, 20, 0.1);
       transform: translateY(-2px);
+    }
+
+    /* Global Search Bar Styles */
+    .global-search-container {
+      position: relative;
+      flex: 1;
+      max-width: 500px;
+      margin: 0 30px;
+      z-index: 9999;
+    }
+
+    .global-search-wrapper {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+
+    .global-search-input {
+      width: 100%;
+      padding: 14px 20px 14px 48px;
+      border: 2px solid rgba(255, 255, 255, 0.1);
+      border-radius: 12px;
+      font-size: 1rem;
+      background: rgba(0, 0, 0, 0.6);
+      color: white;
+      transition: all 0.3s ease;
+      backdrop-filter: blur(10px);
+    }
+
+    .global-search-input::placeholder {
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    .global-search-input:focus {
+      outline: none;
+      border-color: #E50914;
+      background: rgba(0, 0, 0, 0.8);
+      box-shadow: 0 0 0 4px rgba(229, 9, 20, 0.15), 0 8px 32px rgba(0, 0, 0, 0.4);
+    }
+
+    .global-search-icon {
+      position: absolute;
+      left: 16px;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 1.2rem;
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    .global-search-spinner {
+      position: absolute;
+      right: 16px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 20px;
+      height: 20px;
+      border: 2px solid rgba(229, 9, 20, 0.3);
+      border-top-color: #E50914;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      display: none;
+    }
+
+    .global-search-spinner.active {
+      display: block;
+    }
+
+    /* Autocomplete Dropdown */
+    .autocomplete-dropdown {
+      position: absolute;
+      top: calc(100% + 8px);
+      left: 0;
+      right: 0;
+      background: rgba(15, 15, 15, 0.99);
+      border: 2px solid rgba(229, 9, 20, 0.4);
+      border-radius: 12px;
+      box-shadow: 0 25px 80px rgba(0, 0, 0, 0.95), 0 0 0 1px rgba(255, 255, 255, 0.1);
+      backdrop-filter: blur(20px);
+      max-height: 450px;
+      overflow-y: auto;
+      z-index: 9999;
+      display: none;
+      animation: dropdownFadeIn 0.2s ease;
+    }
+
+    .autocomplete-dropdown.active {
+      display: block;
+    }
+
+    @keyframes dropdownFadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(-10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .autocomplete-item {
+      display: flex;
+      align-items: center;
+      gap: 15px;
+      padding: 12px 16px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .autocomplete-item:last-child {
+      border-bottom: none;
+    }
+
+    .autocomplete-item:hover,
+    .autocomplete-item.selected {
+      background: rgba(229, 9, 20, 0.15);
+    }
+
+    .autocomplete-item:first-child {
+      border-radius: 12px 12px 0 0;
+    }
+
+    .autocomplete-item:last-child {
+      border-radius: 0 0 12px 12px;
+    }
+
+    .autocomplete-item:only-child {
+      border-radius: 12px;
+    }
+
+    .autocomplete-poster {
+      width: 45px;
+      height: 68px;
+      border-radius: 6px;
+      object-fit: cover;
+      background: rgba(229, 9, 20, 0.2);
+      flex-shrink: 0;
+    }
+
+    .autocomplete-poster-placeholder {
+      width: 45px;
+      height: 68px;
+      border-radius: 6px;
+      background: linear-gradient(135deg, rgba(229, 9, 20, 0.3), rgba(0, 0, 0, 0.5));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      font-size: 1.5rem;
+    }
+
+    .autocomplete-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .autocomplete-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: white;
+      margin-bottom: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .autocomplete-meta {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 0.85rem;
+      color: #999;
+    }
+
+    .autocomplete-year {
+      color: #E50914;
+      font-weight: 600;
+    }
+
+    .autocomplete-rating {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .autocomplete-rating-star {
+      color: #ffd700;
+    }
+
+    .autocomplete-no-results {
+      padding: 30px 20px;
+      text-align: center;
+      color: #999;
+    }
+
+    .autocomplete-no-results-icon {
+      font-size: 2.5rem;
+      margin-bottom: 10px;
+      opacity: 0.5;
+    }
+
+    .autocomplete-footer {
+      padding: 12px 16px;
+      background: rgba(0, 0, 0, 0.4);
+      border-top: 1px solid rgba(255, 255, 255, 0.05);
+      border-radius: 0 0 12px 12px;
+    }
+
+    .autocomplete-footer-link {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      color: #E50914;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.9rem;
+      transition: all 0.2s ease;
+    }
+
+    .autocomplete-footer-link:hover {
+      color: #ff0a16;
+      gap: 12px;
+    }
+
+    /* Keyboard navigation hint */
+    .autocomplete-hint {
+      padding: 8px 16px;
+      background: rgba(0, 0, 0, 0.3);
+      border-top: 1px solid rgba(255, 255, 255, 0.05);
+      font-size: 0.75rem;
+      color: #666;
+      display: flex;
+      justify-content: center;
+      gap: 16px;
+    }
+
+    .autocomplete-hint kbd {
+      background: rgba(255, 255, 255, 0.1);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-family: inherit;
+      margin: 0 4px;
+    }
+
+    @media (max-width: 768px) {
+      .global-search-container {
+        max-width: none;
+        margin: 15px 0;
+        order: 3;
+        width: 100%;
+      }
+
+      .header {
+        flex-wrap: wrap;
+      }
+
+      .autocomplete-dropdown {
+        position: fixed;
+        top: auto;
+        left: 10px;
+        right: 10px;
+        max-height: 60vh;
+      }
     }
 
     /* Welcome Section */
@@ -852,6 +1120,31 @@
         </div>
         <div class="logo-text">CineMatch</div>
       </div>
+      
+      <!-- Global Search Bar -->
+      <div class="global-search-container">
+        <div class="global-search-wrapper">
+          <span class="global-search-icon">🔍</span>
+          <input 
+            type="text" 
+            class="global-search-input" 
+            id="globalSearchInput"
+            placeholder="Search movies... (e.g., Avatar, Avengers)"
+            autocomplete="off"
+            spellcheck="false"
+          >
+          <div class="global-search-spinner" id="searchSpinner"></div>
+        </div>
+        <div class="autocomplete-dropdown" id="autocompleteDropdown">
+          <div id="autocompleteResults"></div>
+          <div class="autocomplete-hint">
+            <span><kbd>↑</kbd><kbd>↓</kbd> to navigate</span>
+            <span><kbd>Enter</kbd> to select</span>
+            <span><kbd>Esc</kbd> to close</span>
+          </div>
+        </div>
+      </div>
+      
       <div class="header-actions">
         <a href="{% url 'recom_sys:recommend' %}" class="btn btn-primary">
           Get Recommendations
@@ -1391,6 +1684,251 @@
         }
       }
     }
+
+    // ==================== GLOBAL SEARCH BAR - ALGOLIA-STYLE AUTOCOMPLETE ====================
+    
+    const searchInput = document.getElementById('globalSearchInput');
+    const dropdown = document.getElementById('autocompleteDropdown');
+    const resultsContainer = document.getElementById('autocompleteResults');
+    const spinner = document.getElementById('searchSpinner');
+    
+    let debounceTimer = null;
+    let currentQuery = '';
+    let selectedIndex = -1;
+    let currentResults = [];
+    let abortController = null;
+    
+    // Debounced search function
+    function debounceSearch(query, delay = 250) {
+      clearTimeout(debounceTimer);
+      
+      // Cancel previous request
+      if (abortController) {
+        abortController.abort();
+      }
+      
+      if (!query || query.length < 2) {
+        hideDropdown();
+        return;
+      }
+      
+      showSpinner();
+      
+      debounceTimer = setTimeout(() => {
+        performSearch(query);
+      }, delay);
+    }
+    
+    // Perform search API call
+    async function performSearch(query) {
+      currentQuery = query;
+      abortController = new AbortController();
+      
+      try {
+        const response = await fetch(`/api/search/autocomplete/?q=${encodeURIComponent(query)}&limit=8`, {
+          signal: abortController.signal,
+          headers: {
+            'Accept': 'application/json',
+          }
+        });
+        
+        if (!response.ok) throw new Error('Search failed');
+        
+        const data = await response.json();
+        
+        if (data.success && query === currentQuery) {
+          currentResults = data.results;
+          selectedIndex = -1;
+          renderResults(data.results, query);
+        }
+      } catch (error) {
+        if (error.name !== 'AbortError') {
+          console.error('Search error:', error);
+          renderNoResults('Error searching. Please try again.');
+        }
+      } finally {
+        hideSpinner();
+      }
+    }
+    
+    // Render search results
+    function renderResults(results, query) {
+      if (!results || results.length === 0) {
+        renderNoResults(`No movies found for "${query}"`);
+        return;
+      }
+      
+      let html = '';
+      
+      results.forEach((movie, index) => {
+        const posterHtml = movie.poster_url
+          ? `<img src="${movie.poster_url}" alt="${movie.title}" class="autocomplete-poster" loading="lazy">`
+          : `<div class="autocomplete-poster-placeholder">🎬</div>`;
+        
+        const ratingHtml = movie.vote_average > 0
+          ? `<span class="autocomplete-rating"><span class="autocomplete-rating-star">★</span> ${movie.vote_average}</span>`
+          : '';
+        
+        html += `
+          <div class="autocomplete-item" data-index="${index}" data-tmdb-id="${movie.tmdb_id}" data-title="${movie.title}">
+            ${posterHtml}
+            <div class="autocomplete-info">
+              <div class="autocomplete-title">${highlightMatch(movie.title, query)}</div>
+              <div class="autocomplete-meta">
+                ${movie.year ? `<span class="autocomplete-year">${movie.year}</span>` : ''}
+                ${ratingHtml}
+              </div>
+            </div>
+          </div>
+        `;
+      });
+      
+      // Add footer link to full search
+      html += `
+        <div class="autocomplete-footer">
+          <a href="{% url 'recom_sys:movie_search' %}?q=${encodeURIComponent(query)}" class="autocomplete-footer-link">
+            See all results for "${query}" →
+          </a>
+        </div>
+      `;
+      
+      resultsContainer.innerHTML = html;
+      showDropdown();
+      
+      // Add click handlers to results
+      document.querySelectorAll('.autocomplete-item').forEach(item => {
+        item.addEventListener('click', () => selectMovie(item));
+      });
+    }
+    
+    // Highlight matching text
+    function highlightMatch(text, query) {
+      if (!query) return text;
+      const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+      return text.replace(regex, '<strong style="color: #E50914;">$1</strong>');
+    }
+    
+    // Render no results message
+    function renderNoResults(message) {
+      resultsContainer.innerHTML = `
+        <div class="autocomplete-no-results">
+          <div class="autocomplete-no-results-icon">🎬</div>
+          <div>${message}</div>
+        </div>
+      `;
+      showDropdown();
+    }
+    
+    // Select a movie from results
+    function selectMovie(item) {
+      const tmdbId = item.dataset.tmdbId;
+      const title = item.dataset.title;
+      
+      // Navigate to the movie search page with this movie pre-selected
+      window.location.href = `{% url 'recom_sys:movie_search' %}?movie=${tmdbId}&title=${encodeURIComponent(title)}`;
+    }
+    
+    // Keyboard navigation
+    function handleKeyDown(e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const items = document.querySelectorAll('.autocomplete-item');
+        
+        // If an item is selected, use that
+        if (selectedIndex >= 0 && items[selectedIndex]) {
+          selectMovie(items[selectedIndex]);
+        } 
+        // If no item selected but we have results, auto-select the first one
+        else if (currentResults.length > 0 && items.length > 0) {
+          selectMovie(items[0]);
+        }
+        // Fallback: go to search page with query
+        else if (currentQuery) {
+          window.location.href = `{% url 'recom_sys:movie_search' %}?q=${encodeURIComponent(currentQuery)}`;
+        }
+        return;
+      }
+      
+      if (!dropdown.classList.contains('active')) return;
+      
+      const items = document.querySelectorAll('.autocomplete-item');
+      
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          selectedIndex = Math.min(selectedIndex + 1, items.length - 1);
+          updateSelection(items);
+          break;
+          
+        case 'ArrowUp':
+          e.preventDefault();
+          selectedIndex = Math.max(selectedIndex - 1, -1);
+          updateSelection(items);
+          break;
+          
+        case 'Escape':
+          hideDropdown();
+          searchInput.blur();
+          break;
+      }
+    }
+    
+    // Update visual selection
+    function updateSelection(items) {
+      items.forEach((item, index) => {
+        item.classList.toggle('selected', index === selectedIndex);
+      });
+      
+      // Scroll selected item into view
+      if (selectedIndex >= 0 && items[selectedIndex]) {
+        items[selectedIndex].scrollIntoView({ block: 'nearest' });
+      }
+    }
+    
+    // Show/hide dropdown and spinner
+    function showDropdown() {
+      dropdown.classList.add('active');
+    }
+    
+    function hideDropdown() {
+      dropdown.classList.remove('active');
+      selectedIndex = -1;
+    }
+    
+    function showSpinner() {
+      spinner.classList.add('active');
+    }
+    
+    function hideSpinner() {
+      spinner.classList.remove('active');
+    }
+    
+    // Event listeners
+    searchInput.addEventListener('input', (e) => {
+      debounceSearch(e.target.value.trim());
+    });
+    
+    searchInput.addEventListener('keydown', handleKeyDown);
+    
+    searchInput.addEventListener('focus', () => {
+      if (currentResults.length > 0) {
+        showDropdown();
+      }
+    });
+    
+    // Close dropdown when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.global-search-container')) {
+        hideDropdown();
+      }
+    });
+    
+    // Handle paste event
+    searchInput.addEventListener('paste', (e) => {
+      setTimeout(() => {
+        debounceSearch(searchInput.value.trim(), 100);
+      }, 0);
+    });
 
   </script>
 </body>

--- a/recom_sys_app/test_views_solo.py
+++ b/recom_sys_app/test_views_solo.py
@@ -1028,7 +1028,7 @@ class GetWatchedViewTest(TestCase):
         self.client.login(username="testuser", password="testpass123")
 
         # Create watched interactions at different times
-        from datetime import datetime, timedelta
+        from datetime import timedelta
         from django.utils import timezone
 
         old_time = timezone.now() - timedelta(days=30)

--- a/recom_sys_app/urls.py
+++ b/recom_sys_app/urls.py
@@ -108,6 +108,11 @@ urlpatterns = [
     path("search/", views.movie_search_view, name="movie_search"),
     path("api/search/movies/", views.search_movies_api, name="api_search_movies"),
     path(
+        "api/search/autocomplete/",
+        views.autocomplete_movies_api,
+        name="api_autocomplete_movies",
+    ),
+    path(
         "api/movies/<int:tmdb_id>/similar/",
         views.get_similar_movies_api,
         name="api_similar_movies",

--- a/recom_sys_app/views.py
+++ b/recom_sys_app/views.py
@@ -1263,6 +1263,90 @@ def search_movies_api(request):
 
 @login_required
 @require_http_methods(["GET"])
+def autocomplete_movies_api(request):
+    """
+    Lightweight API endpoint for Algolia-style movie autocomplete.
+    Returns multiple relevant movie suggestions as user types.
+
+    Query params:
+        q: Search query string (required)
+        limit: Max results to return (default: 8)
+    """
+    query = request.GET.get("q", "").strip()
+
+    if not query or len(query) < 2:
+        return JsonResponse({"success": True, "results": [], "count": 0})
+
+    try:
+        limit = min(int(request.GET.get("limit", 8)), 15)  # Cap at 15
+    except (ValueError, TypeError):
+        limit = 8
+
+    try:
+        if not TMDB_TOKEN:
+            return JsonResponse(
+                {"success": False, "message": "TMDB API not configured"}, status=500
+            )
+
+        # Use TMDB search API for fast autocomplete
+        r = requests.get(
+            f"{TMDB_BASE}/search/movie",
+            params={
+                "query": query,
+                "include_adult": "False",
+                "language": "en-US",
+                "page": 1,
+            },
+            headers=TMDB_HEADERS,
+            timeout=5,  # Short timeout for autocomplete
+        )
+        r.raise_for_status()
+
+        results = r.json().get("results", [])
+
+        # Format results for autocomplete dropdown
+        formatted_results = []
+        for movie in results[:limit]:
+            release_date = movie.get("release_date", "")
+            year = release_date[:4] if release_date else ""
+
+            formatted_results.append(
+                {
+                    "tmdb_id": movie.get("id"),
+                    "title": movie.get("title"),
+                    "year": year,
+                    "vote_average": round(movie.get("vote_average", 0), 1),
+                    "poster_path": movie.get("poster_path"),
+                    "poster_url": (
+                        f"{IMG_BASE}{movie['poster_path']}"
+                        if movie.get("poster_path")
+                        else None
+                    ),
+                }
+            )
+
+        return JsonResponse(
+            {
+                "success": True,
+                "query": query,
+                "count": len(formatted_results),
+                "results": formatted_results,
+            }
+        )
+
+    except requests.Timeout:
+        return JsonResponse({"success": False, "message": "Search timeout"}, status=504)
+    except requests.HTTPError as e:
+        return JsonResponse(
+            {"success": False, "message": f"TMDB API error: {e.response.status_code}"},
+            status=502,
+        )
+    except Exception as e:
+        return JsonResponse({"success": False, "message": str(e)}, status=500)
+
+
+@login_required
+@require_http_methods(["GET"])
 def get_similar_movies_api(request, tmdb_id):
     """
     API endpoint to get similar movies for a given movie ID

--- a/recommendation_sys/settings.py
+++ b/recommendation_sys/settings.py
@@ -189,8 +189,12 @@ STATIC_URL = "static/"
 # Tell Django where to find static files (for development debugging)
 STATICFILES_DIRS = [
     BASE_DIR / "recom_sys_app" / "static",
-    BASE_DIR / "frontend" / "dist",  # React build directory
 ]
+# Only include frontend/dist if it exists (React build directory)
+_frontend_dist = BASE_DIR / "frontend" / "dist"
+if _frontend_dist.exists():
+    STATICFILES_DIRS.append(_frontend_dist)
+
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # Default primary key field type

--- a/recommendation_sys/urls.py
+++ b/recommendation_sys/urls.py
@@ -3,10 +3,9 @@ URL configuration for recommendation_sys project.
 """
 
 from django.contrib import admin
-from django.urls import path, include, re_path
+from django.urls import path, include
 from django.http import HttpResponse
 from django.shortcuts import redirect
-from django.views.generic import TemplateView
 
 import os
 from django.conf import settings
@@ -17,7 +16,8 @@ def root_view(request):
     """
     Root path handler:
     - Returns 200 OK for ELB health checker
-    - Serves React app for regular users
+    - Serves React app if it exists
+    - Redirects to app home otherwise
     """
     user_agent = request.META.get("HTTP_USER_AGENT", "")
 
@@ -25,19 +25,23 @@ def root_view(request):
     if "ELB-HealthChecker" in user_agent:
         return HttpResponse("OK", status=200)
 
-    # Serve React app
+    # Try to serve React app if it exists
     index_path = os.path.join(settings.BASE_DIR, "frontend", "dist", "index.html")
-    with open(index_path) as f:
-        return HttpResponse(f.read())
+    if os.path.exists(index_path):
+        with open(index_path) as f:
+            return HttpResponse(f.read())
+
+    # Fallback: redirect to Django app home
+    return redirect("recom_sys:home")
 
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path(
         "", include("recom_sys_app.urls", namespace="recom_sys")
-    ),  # App routes - MUST come first
-    re_path(r"^.*$", root_view),  # Catch-all for React routes (SPA)
+    ),  # App routes - handles all app URLs including home
 ]
+
 if settings.DEBUG:
     urlpatterns += static(
         settings.STATIC_URL,


### PR DESCRIPTION
- Add persistent global search bar in profile page header
- Add autocomplete API endpoint (/api/search/autocomplete/) for fast movie search
- Implement debounced search (250ms) with dropdown suggestions
- Add keyboard navigation (Arrow keys, Enter, Escape)
- Enter key auto-selects first result when no item is highlighted
- Fix dropdown z-index to appear above page content
- Add search bar to movie_search page with URL param handling
- Fix staticfiles warning by making frontend/dist conditional
- Fix URL routing issue preventing admin access
- Fix unused imports (flake8 compliance)
- All files pass black formatting and flake8 linting