### PR TITLE
fix: Configure WhiteNoise for static files in production

### DIFF
--- a/recommendation_sys/settings.py
+++ b/recommendation_sys/settings.py
@@ -199,14 +199,27 @@ if _frontend_dist.exists():
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # WhiteNoise configuration for serving static files in production
-STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-    },
-}
+# Only use manifest storage in production (requires collectstatic to be run first)
+if DEBUG:
+    # In development/testing, use simple storage that doesn't require manifest
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
+else:
+    # In production, use WhiteNoise with compression and manifest
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        },
+    }
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field


### PR DESCRIPTION
- Add WhiteNoise middleware after SecurityMiddleware
- Fix STATIC_URL to use absolute path (/static/)
- Add STORAGES configuration with CompressedManifestStaticFilesStorage
- This fixes logo and other static assets not loading in production