### PR TITLE
fix: Add edge flag to Travis deployment for better AWS credential han…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ deploy:
   bucket_name: elasticbeanstalk-us-east-1-028210901732
   bucket_path: cinematch-app
   skip_cleanup: true
+  # Ensure credentials are properly set
+  edge: true
   on:
     branch: develop
     python: "3.12"


### PR DESCRIPTION
…dling

- Add edge: true to use latest dpl version
- Helps resolve SignatureDoesNotMatch errors with special characters in secrets
- Ensures proper encoding of AWS credentials